### PR TITLE
New command-line flag to disable recursive behavior on Tables

### DIFF
--- a/src/BaselineService.cs
+++ b/src/BaselineService.cs
@@ -14,7 +14,7 @@ namespace Yuniql.Extensions
         private List<string> processedUrns = new List<string>();
         public delegate bool FilterDelegate(Urn urn);
 
-        public void Run(string sourceConnectionString, string destinationFullPath)
+        public void Run(string sourceConnectionString, string destinationFullPath, bool IsTableDependencyDisabled)
         {
             var connectionStringBuilder = new SqlConnectionStringBuilder(sourceConnectionString);
 
@@ -47,7 +47,7 @@ namespace Yuniql.Extensions
             GenerateSchemaBasedScriptFiles(sourceConnectionString, scripter, xmlschemasDirectory, xmlschemasUrns);
 
             var tableDirectory = GetOrCreateDestinationDirectory(destinationFullPath, "04-tables");
-            var tableUrns = GetTableUrns(database, scripter);
+            var tableUrns = IsTableDependencyDisabled ? GetGenericUrns(database.Tables) : GetTableUrns(database, scripter);
             GenerateSchemaBasedScriptFiles(sourceConnectionString, scripter, tableDirectory, tableUrns);
 
             var viewDirectory = GetOrCreateDestinationDirectory(destinationFullPath, "05-views");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,7 +35,7 @@ namespace Yuniql.Extensions
                 }
 
                 var baselineService = new BaselineService();
-                baselineService.Run(opts.ConnectionString, opts.Path);
+                baselineService.Run(opts.ConnectionString, opts.Path, opts.IsTableDependencyDisabled);
 
                 TraceService.Info($"Initialized {opts.Path}.");
             }
@@ -64,5 +64,10 @@ namespace Yuniql.Extensions
         //yuniqlx baseline -d | --debug
         [Option('d', "debug", Required = false, HelpText = "Print debug information including all raw scripts")]
         public bool Debug { get; set; }
+
+        //yuniqlx baseline -n | --no-dependencies
+        [Option('n', "no-dependencies", Required = false, HelpText = "Do not recursively fetch definitions of dependent objects")]
+        public bool IsTableDependencyDisabled { get; set; }
+
     }
 }


### PR DESCRIPTION
Git comments:
Introduce --no-dependencies flag to treat Tables like any other object, and not recursively fetch dependent object definitions

Experience:
In our environment, the stock behavior would cause:

- objects landing in the "wrong" folder (i.e. some scalar functions would have their definition placed in the Tables folder and not in the Functions folder)
- objects being imported from other databases (because of cross-database queries), but without qualification by database name, appearing to be duplicates of local objects
  - sometimes they were nearly-identical (i.e. utility functions deployed everywhere)
  - sometimes they were drastically different (tables named coincidentally similarly but different structures and intentions)
- The only reason these duplications didn't totally explode was the numeric prefix on files (which I was personally removing after the fact in powershell, which is when this problem became obvious)

The way we're using this, we have yuniql forward-migration folders that we truly depend on, but want to also maintain a current copy of the schema-model in git to help detect conflicting changes from different committers (i.e. different migration files but same schema-model file). For that purpose, objects need to always be in the right folders (no risk of moving around because of dependency changes) and always named the same (no numeric prefix that can change over time as a result of dependencies or siblings being added or removed.) I didn't address the removal of numeric prefixes in this commit, but it might be a useful followup. 

While I'm mentioning use-cases: yuniqlx currently appends to files rather than replacing, so I have to run it in a fresh temporary folder, then copy the resulting files back on top of the real files (in the git workspace) only when they've truly changed (hash comparison) so my git client won't see spurious changes by timestamp. (And then also delete any workspace files that are no longer detected in the yuniqlx temporary folder.) Switching to replace rather than append wouldn't be enough to simplify that workflow, so it's just something to think about: "I want my folder to be replaced with a folder representing all and only the objects as they now exist, but not modifying timestamps on files that haven't really changed."
